### PR TITLE
Review instructions for updating the OME website

### DIFF
--- a/docs/jekyll.rst
+++ b/docs/jekyll.rst
@@ -77,10 +77,10 @@ static website and then deploying it on the web server:
 - after pushing the tag, an artifact of the static website will be built by
   [GitHub Actions](https://github.com/ome/www.openmicroscopy.org/actions) and 
   deployed as an asset of the associated `GitHub release <https://github.com/ome/www.openmicroscopy.org/releases>`_
-- to update the static website, either the :command:`sudo deploy -f` command
-  should be executed from the OME website server or the full
-  `www Ansible playbook <https://github.com/ome/prod-playbooks/blob/master/www/playbook.yml>`_
-  can be executed.
+- on the server hosting the website, a cron job will update the website hourly
+  if a new release has been created on GitHub
+- if needed, the static website can also be updated manually by executing the
+  :command:`sudo deploy -f` command from the OME website server.
 
 OME Blog
 ^^^^^^^^

--- a/docs/jekyll.rst
+++ b/docs/jekyll.rst
@@ -72,7 +72,7 @@ static website and then deploying it on the web server:
 
 - to release the Jekyll source code, a signed Git tag needs to be created from
   the master branch of the source code. Website tags must follow the
-  `Calendar Versioning <https://calver.org/#youtube-dl>`_ scheme using the tag
+  `Calendar Versioning <https://calver.org/>`_ scheme using the tag
   date
 - after pushing the tag, an artifact of the static website will be built by
   `GitHub Actions <https://github.com/ome/www.openmicroscopy.org/actions>`_

--- a/docs/jekyll.rst
+++ b/docs/jekyll.rst
@@ -72,11 +72,12 @@ static website and then deploying it on the web server:
 
 - to release the Jekyll source code, a signed Git tag needs to be created from
   the master branch of the source code. Website tags must follow the
-  [Calendar Versioning](https://calver.org/#youtube-dl) scheme using the tag
+  `Calendar Versioning <https://calver.org/#youtube-dl>`_ scheme using the tag
   date
 - after pushing the tag, an artifact of the static website will be built by
-  [GitHub Actions](https://github.com/ome/www.openmicroscopy.org/actions) and 
-  deployed as an asset of the associated `GitHub release <https://github.com/ome/www.openmicroscopy.org/releases>`_
+  `GitHub Actions <https://github.com/ome/www.openmicroscopy.org/actions>`_
+  and deployed as an asset of the associated
+  `GitHub release <https://github.com/ome/www.openmicroscopy.org/releases>`_
 - on the server hosting the website, a cron job will update the website hourly
   if a new release has been created on GitHub
 - if needed, the static website can also be updated manually by executing the


### PR DESCRIPTION
--depends-on https://github.com/ome/prod-playbooks/pull/311

The manual execution of the `deploy` script is now optional (superseded by the hourly cron job)