### PR TITLE
Maven components release updates

### DIFF
--- a/docs/java-development.rst
+++ b/docs/java-development.rst
@@ -149,7 +149,7 @@ versions plugin::
 
     $ mvn versions:set -DnewVersion=x.y.z -DgenerateBackupPoms=false
     $ git add -u .
-    $ git commit -m “Bump release version to x.y.z”
+    $ git commit -m "Bump release version to x.y.z"
 
 Additionally, a PGP-signed tag should be created for the released version e.g.
 using :command:`scc tag-release` or more simply :command:`git tag -s`::
@@ -210,7 +210,7 @@ plugin again::
     # Where w == z+1
     $ mvn versions:set -DnewVersion=x.y.w-SNAPSHOT -DgenerateBackupPoms=false
     $ git add -u .
-    $ git commit -m “Bump release version to x.y.w-SNAPSHOT”
+    $ git commit -m "Bump release version to x.y.w-SNAPSHOT"
     $ git push origin master
 
 Javadoc

--- a/docs/java-development.rst
+++ b/docs/java-development.rst
@@ -168,7 +168,7 @@ versions plugin::
 Additionally, a PGP-signed tag should be created for the released version e.g.
 using :command:`git tag -s`::
 
-    $ git tag -s -m "Release version x.y.x" vx.y.z
+    $ git tag -s -m "Release version x.y.z" vx.y.z
 
 Optionally, push the master branch and the tag to your fork for validation by another
 member of the team::
@@ -203,7 +203,7 @@ the release phase of the nexus-staging plugin::
 The rsync to Central Maven and the update of Maven search usually happen
 within a couple of hours but the components are accessible beforehand.
 
-Once the tag is validated, the tag can  be pushed to the organization repository::
+Once the tag is validated, the tag can be pushed to the organization repository::
 
     $ git push origin vx.y.z
 

--- a/docs/java-development.rst
+++ b/docs/java-development.rst
@@ -170,7 +170,7 @@ using :command:`git tag -s`::
 
     $ git tag -s -m "Release version x.y.x" vx.y.z
 
-Push the master branch and the tag to your fork for validation by another
+Optionally, push the master branch and the tag to your fork for validation by another
 member of the team::
 
     $ git push <fork_name> master
@@ -203,17 +203,15 @@ the release phase of the nexus-staging plugin::
 The rsync to Central Maven and the update of Maven search usually happen
 within a couple of hours but the components are accessible beforehand.
 
-Once the tag is validated, the master branch and the tag can also be pushed to
-the organization repository together::
+Once the tag is validated, the tag can  be pushed to the organization repository::
 
     $ git push origin vx.y.z
-    $ git push origin master
 
 Next development version
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Then finally restore the new development version using e.g. the Maven versions
-plugin again::
+Finally create a commit to bump the new development version e.g. using the Maven
+versions plugin again and push the master branch::
 
     # Where w == z+1
     $ mvn versions:set -DnewVersion=x.y.w-SNAPSHOT -DgenerateBackupPoms=false

--- a/docs/java-development.rst
+++ b/docs/java-development.rst
@@ -110,19 +110,33 @@ Release process
 Maintainer prerequisites
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-It is important to get familiar with the
-`OSSRH guide <https://central.sonatype.org/pages/ossrh-guide.html>`__ and
-especially the
-`Maven section for performing a release deployment <https://central.sonatype.org/pages/apache-maven.html>`__.
+To be able to maintain a Java component, a developer must have:
 
-To be able to maintain a Java component, a developer must:
+- a GitHub_ account with push rights to the GitHub source code repository
+- a Sonatype_ account and be registered as a maintainer of the
+  `org.openmicroscopy` repository
+- a valid PGP key for signing the tags and the JARs
+- a local :file:`~/.m2/settings.xml` file configured with an access token
+  generated as described in https://central.sonatype.org/publish/generate-token
 
-- have a GitHub_ account and have push rights to the GitHub source code
-  repository
-- have a Sonatype_ account and be registered as a maintainer of the
-  `org.openmicroscopy` repository (JIRA issues should be opened for each
-  developer)
-- have a valid PGP key for signing the tags and the JARs
+Follow the instructions at https://central.sonatype.org/register/legacy to
+create a Sonatype account allowing to publish via OSSRH. You need to
+contact Central Support to be able to release the artifacts of
+groupId `org.openmicroscopy`.
+
+.. seealso:
+
+    https://central.sonatype.org/register/legacy
+      Registration instructions to public via OSSRH
+
+    https://central.sonatype.org/publish/publish-guide/
+      Publishing via OSSRH
+
+    https://central.sonatype.org/publish/generate-token
+      Generating a token for publishing via OSSRH
+
+    https://central.sonatype.org/publish/publish-maven/
+      Deploying to OSSRH with Apache Maven
 
 Release strategies
 ^^^^^^^^^^^^^^^^^^
@@ -180,17 +194,11 @@ Release promotion
 At the moment all Java components use the Nexus Staging Maven plugin with the
 `autoReleaseAfterClose` option set to `false`. A separate promotion step is
 necessary for releasing the component to the Sonatype releases repository.
-This promotion can happen either via the Sonatype UI using the Release button
-or using the release phase of the nexus-staging plugin::
+This promotion can happen either via the Sonatype UI as described in
+https://central.sonatype.org/publish/release/ or via command-line using
+the release phase of the nexus-staging plugin::
 
     $ mvn nexus-staging:release -P release
-
-See the 'Manually Releasing the Deployment to the Central Repository' section
-of the
-`Apache Maven guide <https://central.sonatype.org/pages/apache-maven.html>`_
-for more instructions. You should be able to find the staged repository by
-visiting `<https://oss.sonatype.org/#stagingRepositories>`_ and searching for
-"org.openmicroscopy".
 
 The rsync to Central Maven and the update of Maven search usually happen
 within a couple of hours but the components are accessible beforehand.

--- a/docs/java-development.rst
+++ b/docs/java-development.rst
@@ -124,7 +124,7 @@ create a Sonatype account allowing to publish via OSSRH. You need to
 contact Central Support to be able to release the artifacts of
 groupId `org.openmicroscopy`.
 
-.. seealso:
+.. seealso::
 
     https://central.sonatype.org/register/legacy
       Registration instructions to public via OSSRH

--- a/docs/java-development.rst
+++ b/docs/java-development.rst
@@ -166,9 +166,9 @@ versions plugin::
     $ git commit -m "Bump release version to x.y.z"
 
 Additionally, a PGP-signed tag should be created for the released version e.g.
-using :command:`scc tag-release` or more simply :command:`git tag -s`::
+using :command:`git tag -s`::
 
-    $ scc tag-release -s x.y.z --prefix v
+    $ git tag -s -m "Release version x.y.x" vx.y.z
 
 Push the master branch and the tag to your fork for validation by another
 member of the team::

--- a/docs/java-development.rst
+++ b/docs/java-development.rst
@@ -114,7 +114,7 @@ To be able to maintain a Java component, a developer must have:
 
 - a GitHub_ account with push rights to the GitHub source code repository
 - a Sonatype_ account and be registered as a maintainer of the
-  `org.openmicroscopy` repository
+  `org.openmicroscopy` repository, if the artifact is deployed to Maven Central
 - a valid PGP key for signing the tags and the JARs
 - a local :file:`~/.m2/settings.xml` file configured with an access token
   generated as described in https://central.sonatype.org/publish/generate-token


### PR DESCRIPTION
Fixes various issues noted during the `ome-common-java` release with @joshmoore @melissalinkert and @dgault yesterday

The Sonatype/OSSRH instructions have been updated to use to the new guide pages, document the requirement to set-up `~/.m2/settings.xml` and use access tokens.

Mid-term, we should probably review the impact of https://central.sonatype.org/news/20240301_changes_to_account_management/ on all OME Java components which are still published via OSSRH and evaluate the process for migrating to the new Central publication mechanism but this is outside the scope of this PR