### PR TITLE
Add third-party contribution policy to contributing documentation

### DIFF
--- a/docs/general.rst
+++ b/docs/general.rst
@@ -9,6 +9,7 @@ The following sections summarize general work practises followed by the OME team
 
     source-code
     using-git
+    third-party-policy
     code-contributions
     cla
     team-communication

--- a/docs/third-party-policy.rst
+++ b/docs/third-party-policy.rst
@@ -1,0 +1,103 @@
+Third Party Contribution and Interaction Policy
+===============================================
+
+Introduction
+------------
+
+In 2016, OME published its first statement on
+`supporting file formats in Bio-Formats <https://www.openmicroscopy.org/2016/01/06/format-support.html>`__.
+This was refined further with `a follow up <https://www.openmicroscopy.org/2019/06/25/formats.html>`__
+in 2019. OME’s position remains largely unchanged but with the very
+welcome increased interest in third party contributions as well as an increased
+number of third party interactions, in particular from instrumentation vendors,
+over the last few years we felt it appropriate to refine and expand upon these
+with an official policy. This policy is designed to clarify what you as a third
+party can expect from OME and what OME expects of you and any organization you
+are representing during interactions with OME.
+
+Communication
+-------------
+
+OME has two main methods of primary communication:
+
+- public community support, best effort,
+- private commercial relationship, SLA, and contractual terms.
+
+The wider community, OME’s academically funded staff, and Glencoe Software
+participate primarily in the first of these methods using the
+`Scientific Community Image Forum <image.sc>`_ discussion forum for scientific
+image software sponsored by the Center for Open Bioimage Analysis (COBA) and
+through OME’s GitHub repositories. OME’s academically funded staff endeavours
+to at least reply to new threads within 24 hours. Here the communication
+expectations follow time honoured BBS and public internet forum etiquette of
+“no support via private message unless invited.”
+
+The rationale for this is simple:
+
+1. the entire community benefits when a discussion surrounding a problem
+   and potential solution can be seen and contributed to by the entire community 
+2. a community member giving up their time and demonstrating their expertise
+   without expectation of compensation is not obligated to support you privately.
+
+Glencoe Software participates in the second of these methods via contract work
+and the Software Maintenance Agreements it has with its licensees of Bio-Formats
+and OMERO. One of the expressed purposes of its existence is to provide private
+support guided by contractual terms and conditions.
+
+Receipt of Sample Data
+----------------------
+
+OME regularly receives, solicited and unsolicited, sample data primarily when
+discussing and attempting to address file format problems issues in Bio-Formats.
+It is the expectation when providing sample data to OME’s academically funded
+staff that the data may be made public unless otherwise stated under a liberal
+license, at least 
+`Creative Commons Attribution 4.0 International License <https://creativecommons.org/licenses/by/4.0/>`_.
+Providing data that cannot be made public is strongly discouraged. Doing so may
+dramatically delay addressing an issue as the team has to assess the benefit of
+doing so against the future maintenance burden to third party contributors who
+will not have access to such data.
+
+Glencoe Software accepts sample data that must remain private and confidential
+under the terms of its contract work and Software Maintenance Agreements. For
+new file format work undertaken on the behalf of instrumentation vendors,
+Glencoe Software always insists that any test data used to validate its work
+can be made publicly available via OME.
+
+All publicly available sample data is made available
+`here <https://downloads.openmicroscopy.org/images/>`__.
+
+Third Party Contributions
+-------------------------
+
+OME encourages third party contributions including from instrumentation vendors
+who are the subject matter experts on their respective proprietary file formats.
+It expects these contributions to come in one of these forms:
+
+- public contributions of expertise or support without expectation of remuneration
+  on the `Scientific Community Image Forum <image.sc>`_ and through OME’s GitHub
+  repositories.
+- appropriately licensed :doc:`code contributions <code-contributions>` to OME’s
+  GitHub repositories made via Pull Request in the primary programming language
+  of that repository.
+  OME is under no obligation to accept such contributions. Private, funded
+  projects undertaken with Glencoe Software on behalf of the third party with
+  the expectation that code will be contributed under
+  `appropriate license <https://www.openmicroscopy.org/licensing/>`_ to OME’s
+  GitHub repositories.
+
+All individual code contributors are expected to fill and return the
+:doc:`OME Contributor License Agreement <cla>`. The agreement is between OME,
+represented by the University of Dundee, and the copyright owner or the legal
+entity authorized by the copyright owner and is valid for all contributions
+across all OME repositories.
+
+Proprietary Native Code Blobs
+-----------------------------
+
+OME can not tolerate any contributions that rely upon proprietary native code
+blobs such as dynamic or statically linked libraries, and SDKs. The maintenance
+and support responsibility for any such native code blob remains entirely with
+the contributor. OME will direct support issues it receives to the contributor
+publicly and any current or future compatibility testing with the native code
+blob with OME software is performed on a best effort basis.

--- a/docs/third-party-policy.rst
+++ b/docs/third-party-policy.rst
@@ -26,11 +26,12 @@ OME has two main methods of primary communication:
 The wider community, OME’s academically funded staff, and Glencoe Software
 participate primarily in the first of these methods using the
 `Scientific Community Image Forum <image.sc>`_ discussion forum for scientific
-image software sponsored by the Center for Open Bioimage Analysis (COBA) and
-through OME’s GitHub repositories. OME’s academically funded staff endeavours
-to at least reply to new threads within 24 hours. Here the communication
-expectations follow time honoured BBS and public internet forum etiquette of
-“no support via private message unless invited.”
+image software sponsored by the
+`Center for Open Bioimage Analysis (COBA) <https://openbioimageanalysis.org/>`_
+and through OME’s GitHub repositories. OME’s academically funded staff
+endeavours to at least reply to new threads within 24 hours. Here the
+communication expectations follow time honoured BBS and public internet forum
+etiquette of “no support via private message unless invited”.
 
 The rationale for this is simple:
 

--- a/docs/third-party-policy.rst
+++ b/docs/third-party-policy.rst
@@ -53,6 +53,9 @@ It is the expectation when providing sample data to OME’s academically funded
 staff that the data may be made public unless otherwise stated under a liberal
 license, at least 
 `Creative Commons Attribution 4.0 International License <https://creativecommons.org/licenses/by/4.0/>`_.
+The recommended way to submit public sample data is to use the
+`Bio-Formats Zenodo community <https://zenodo.org/communities/bio-formats>`_.
+
 Providing data that cannot be made public is strongly discouraged. Doing so may
 dramatically delay addressing an issue as the team has to assess the benefit of
 doing so against the future maintenance burden to third party contributors who


### PR DESCRIPTION
This document had been drafted a few years ago but was never published in an official form. With the recent work on the OME contributing documentation, now feels like a good time to introduce a reference page for third-party entities contributing to the OME repositories.

I have not made any significant modification to the content which had been reviewed internally and limited myself to include cross-references to other sections of the contributing documentation.
Note that https://ome-contributing.readthedocs.io/en/latest/code-contributions.html is the existing page which presents the biggest overlap with this content as it includes:

1. technical recommendations about individual contributions (header, copyrights, pull request)
2. the process for reviewing and integrating the changes.

I'll leave it to the reviewers to decide on whether it is better to separate the high-level guidelines from the process details or merge the content of both pages.

/cc @melissalinkert 