### PR TITLE
Add step to update file sizes on download page

### DIFF
--- a/docs/bioformats-release-process.rst
+++ b/docs/bioformats-release-process.rst
@@ -198,6 +198,7 @@ To make a release:
  - Update the version in `_config.yml <https://github.com/ome/www.openmicroscopy.org/tree/master/_config.yml>`_
  - Add a new entry under `_posts <https://github.com/ome/www.openmicroscopy.org/tree/master/_posts>`_. The name of the post should be ``YYYY-MM-DD-bio-formats-MAJOR-MINOR-PATCH.md`` e.g. ``2024-10-24-bio-formats-8-0-0.md``
  - Point to the post announcing the release in `bio-formats/downloads/index.html <https://github.com/ome/www.openmicroscopy.org/tree/master/bio-formats/downloads/index.html>`_.
+ - Check and, if necessary, update artifact file sizes in `bio-formats/downloads/index.html <https://github.com/ome/www.openmicroscopy.org/tree/master/bio-formats/downloads/index.html>`_.
  - Add, in alphabetical order, new contributors to `_data/bio-formats.json <https://github.com/ome/www.openmicroscopy.org/tree/master/_data/bio-formats.json>`_ and `_data/contributors.json <https://github.com/ome/www.openmicroscopy.org/tree/master/_data/contributors.json>`_.
 
 A signed tag must be created using :command:`git tag -s`::


### PR DESCRIPTION
Each of the artifacts on the Bio-Formats download page has a file size listed. These haven't been routinely checked, and are quite out of date, e.g. `bioformats_package.jar` is listed as 31.64 MB but the file in https://downloads.openmicroscopy.org/bio-formats/8.1.0/artifacts/ works out to 43.47 MB.