### PR TITLE
Remove requirement to update spreadsheet on OMERO release

### DIFF
--- a/docs/omero-release-process.rst
+++ b/docs/omero-release-process.rst
@@ -110,6 +110,5 @@ Both the `master` branch as well as the tag must be pushed upstream::
 
 An hourly cron job runs on our virtual machine and deploys the website.
 
-Finally 
- - Add an entry in https://docs.google.com/spreadsheets/d/1K7ab1UpuiE3FmAq3et7OpyxFwumrT7z8tGrDDBSDxsk/edit#gid=908994883
- - Announce the release on `image.sc <https://forum.image.sc/>`_ using the ``Announcements`` category after checking that the website has been deployed.
+Finally, announce the release on `image.sc <https://forum.image.sc/>`_ using the
+`Announcements <https://forum.image.sc/c/announcements/10>`_ category after checking that the website has been deployed.


### PR DESCRIPTION
This release step links to a private spreadsheet which had been historically updated after every Bio-Formats or OMERO release. As the rationale for maintaining this document is unclear, this PR proposes to remove this step entirely to focus on the public aspect of the release.

In case a timeline is valuable e.g. for reporting or grant purposes, it should be possible to retrieve dynamically all this information from GitHub tags and releases across the relevant components