### PR TITLE
Add initial page describing the OME security process

### DIFF
--- a/docs/bioformats-release-process.rst
+++ b/docs/bioformats-release-process.rst
@@ -14,7 +14,7 @@ Before starting the release process:
 - follow the steps of the :doc:`security-process` if the release fixes a security vulnerability
 - make sure GitHub actions are active on the Bio-Formats repositories
 - open a Pull Request against the `Bio-Formats Documentation`_ with a new release entry in the `whats-new <https://github.com/ome/bio-formats-documentation/blob/master/sphinx/about/whats-new.rst>`_ page
-- if any new reader or writer options were added, open a pull request is opened to update `the options page <https://github.com/ome/bio-formats-documentation/blob/master/sphinx/formats/options.rst>`_ and relevant `format page entries <https://github.com/ome/bio-formats-documentation/blob/master/src/main/resources/format-pages.txt>`_
+- if any new reader or writer options were added, open a pull request to update `the options page <https://github.com/ome/bio-formats-documentation/blob/master/sphinx/formats/options.rst>`_ and relevant `format page entries <https://github.com/ome/bio-formats-documentation/blob/master/src/main/resources/format-pages.txt>`_
 - if any new readers or writers were added, open a pull request to add them to the `list of supported formats <https://github.com/ome/bio-formats-documentation/blob/master/src/main/resources/format-pages.txt>`_
 
 When all changes are approved by both the OME team and the Glencoe Software team, merge documentation pull requests and start the release process.

--- a/docs/bioformats-release-process.rst
+++ b/docs/bioformats-release-process.rst
@@ -8,16 +8,16 @@ Bio-Formats release
 .. _Data Repository: https://github.com/openmicroscopy/data_repo_config
 
 This document describes the release process of the `Bio-Formats`_ Java library.
-The release process uses GitHub actions, make sure that the actions are active before pushing any tag.
 
-Before starting the release process, make sure documentation is updated appropriately:
+Before starting the release process:
 
-- open a Pull Request with a new release entry in the `whats-new <https://github.com/ome/bio-formats-documentation/blob/master/sphinx/about/whats-new.rst>`_ page
-- if any new reader or writer options were added, open a pull request to update `the options page <https://github.com/ome/bio-formats-documentation/blob/master/sphinx/formats/options.rst>`_ and relevant `format page entries <https://github.com/ome/bio-formats-documentation/blob/master/src/main/resources/format-pages.txt>`_
+- follow the steps of the :doc:`security-process` if the release fixes a security vulnerability
+- make sure GitHub actions are active on the Bio-Formats repositories
+- open a Pull Request against the `Bio-Formats Documentation`_ with a new release entry in the `whats-new <https://github.com/ome/bio-formats-documentation/blob/master/sphinx/about/whats-new.rst>`_ page
+- if any new reader or writer options were added, open a pull request is opened to update `the options page <https://github.com/ome/bio-formats-documentation/blob/master/sphinx/formats/options.rst>`_ and relevant `format page entries <https://github.com/ome/bio-formats-documentation/blob/master/src/main/resources/format-pages.txt>`_
 - if any new readers or writers were added, open a pull request to add them to the `list of supported formats <https://github.com/ome/bio-formats-documentation/blob/master/src/main/resources/format-pages.txt>`_
 
 When all changes are approved by both the OME team and the Glencoe Software team, merge documentation pull requests and start the release process.
-
 
 Source code release
 -------------------
@@ -219,18 +219,17 @@ Both the `master` branch as well as the tag must be pushed upstream::
 An hourly cron job runs on our virtual machine and deploys the website.
 
 
+
 Announcement
 ------------
 
- - Announce the release on `image.sc`_ using the ``Announcements`` category after checking that the website has been deployed.
- - Announce on the Confocal email
- - Announce on Bluesky and Linkedin
-
+Announce the release on `image.sc`_ using the
+`Announcements <https://forum.image.sc/c/announcements/10>`_ category after
+checking that the website has been deployed.
 
 Post Release
 ------------
 
- - Add an entry in `Web Server Stats`_.
  - Bump Bio-Formats version in `omero-model <https://github.com/ome/omero-model/blob/master/build.gradle>`_.
  - Bump Bio-Formats version in `pom-scijava <https://github.com/scijava/pom-scijava/blob/master/pom.xml>`_.
 

--- a/docs/build-and-release.rst
+++ b/docs/build-and-release.rst
@@ -34,5 +34,6 @@ Release
     java-development
     omero-release-process
     omero-web-release-process
+    security-process
     python-components
     

--- a/docs/omero-release-process.rst
+++ b/docs/omero-release-process.rst
@@ -8,10 +8,11 @@ OMERO.server release
 .. _Read The Docs: https://readthedocs.org/projects/omero/builds/
 
 This document describes the release process for OMERO_ server.
-The release process uses GitHub actions, make sure that the actions are active before pushing any tag.
 
-Release process
-^^^^^^^^^^^^^^^
+Before starting the release process:
+
+- follow the steps of the :doc:`security-process` if the release fixes a security vulnerability
+- make sure GitHub actions are active on the OMERO.server repositories
 
 Source code release
 -------------------
@@ -103,5 +104,9 @@ Both the `master` branch as well as the tag must be pushed upstream::
 
 An hourly cron job runs on our virtual machine and deploys the website.
 
-Finally, announce the release on `image.sc <https://forum.image.sc/>`_ using the
-`Announcements <https://forum.image.sc/c/announcements/10>`_ category after checking that the website has been deployed.
+Announcement
+------------
+
+Announce the release on `image.sc`_ using the
+`Announcements <https://forum.image.sc/c/announcements/10>`_ category after
+checking that the website has been deployed.

--- a/docs/omero-release-process.rst
+++ b/docs/omero-release-process.rst
@@ -10,13 +10,6 @@ OMERO.server release
 This document describes the release process for OMERO_ server.
 The release process uses GitHub actions, make sure that the actions are active before pushing any tag.
 
-Register CVE
-^^^^^^^^^^^^
-
-As soon as a vulnerability is identified, create a security advisory on `GitHub <https://github.com/ome/openmicroscopy/security/advisories>`_.
-The work to fix the vulnerability will be done using the private copy of `ome/openmicroscopy <https://github.com/ome/openmicroscopy/>`_ and the private copies of the Java components.
-The release process needs to be adjusted in that case.
-
 Release process
 ^^^^^^^^^^^^^^^
 

--- a/docs/omero-web-release-process.rst
+++ b/docs/omero-web-release-process.rst
@@ -7,14 +7,6 @@ OMERO.web release
 This document describes the release process for `OMERO Web`_.
 The release process uses GitHub actions, make sure that the actions are **active** before pushing any tag.
 
-
-Register CVE
-^^^^^^^^^^^^
-
-As soon as a vulnerability is identified, create a security advisory on `GitHub <https://github.com/ome/omero-web/security/advisories>`_.
-The work to fix the vulnerability will be done using the private copy of `ome/omero-web <https://github.com/ome/omero-web/>`_.
-The release process needs to be adjusted in that case.
-
 Release process
 ^^^^^^^^^^^^^^^
 

--- a/docs/omero-web-release-process.rst
+++ b/docs/omero-web-release-process.rst
@@ -5,10 +5,11 @@ OMERO.web release
 .. _OMERO Web Docker: https://github.com/ome/omero-web-docker/
 
 This document describes the release process for `OMERO Web`_.
-The release process uses GitHub actions, make sure that the actions are **active** before pushing any tag.
 
-Release process
-^^^^^^^^^^^^^^^
+Before starting the release process:
+
+- follow the steps of the :doc:`security-process` if the release fixes a security vulnerability
+- make sure GitHub actions are active on the OMERO.web repositories
 
 Source code release
 -------------------
@@ -51,5 +52,10 @@ Both the `master` branch as well as the tag must be pushed upstream::
 
 An hourly cron job runs on our virtual machine and deploys the website.
 
-Finally 
-- Announce the release on `image.sc`_ using the ``Announcements`` category after checking that the website has been deployed.
+
+Announcement
+------------
+
+Announce the release on `image.sc`_ using the
+`Announcements <https://forum.image.sc/c/announcements/10>`_ category after
+checking that the website has been deployed.

--- a/docs/security-process.rst
+++ b/docs/security-process.rst
@@ -1,0 +1,72 @@
+Security process
+================
+
+OME makes extensive use of GitHub  for managing vulnerability reports and fixes - see
+https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities.
+
+Create draft advisory
+^^^^^^^^^^^^^^^^^^^^^
+
+Once a vulnerability is [reported](https://www.openmicroscopy.org/security/) through
+the security mailing list, an administrator should draft a security advisory
+against the appropriate GitHub repository e.g.
+https://github.com/ome/omero-web/security/advisories. This advisory can be used for
+private discussions about the report and the fix. Comments on an advisory will not
+be available publicly but will remain available to the project maintainers.
+
+The vulnerability report should first be reviewed by the project maintainers, acknowledging
+its receipt to the report and engaging for additional information as necessary.
+
+If the reported problem is not identified as a security risk and a draft advisory has
+been created, it must be closed with a comment explaining why it is not considered.
+
+Fix a reported vulnerability
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the problem has been identified as a security risk, a temporary private fork of
+the relevant repository should be created from the draft advisory, see
+https://docs.github.com/en/code-security/tutorials/fix-reported-vulnerabilities/collaborate-in-a-fork/.
+
+Collaborators can be added and removed from the private fork as described in 
+https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/fix-reported-vulnerabilities/add-collaborators
+and https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/fix-reported-vulnerabilities/remove-collaborators
+as necessary.
+
+The development and review process can then proceed as usual using pull requests
+against the private fork.
+
+Announce the security release
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once a fix has been identified, a pre-announcement of the upcoming security release
+should be made on the image.sc forum including at least the `ome` and `security` tags.
+The delay between the publication pre-announcement and the security release  may vary
+depending on a number of factors. For OMERO security releases, sufficient notice should
+be given to system administrators to plan and schedule a downtime and upgrade.
+
+Prepare the advisory
+^^^^^^^^^^^^^^^^^^^^
+
+Prior to its publication, the content advisory should be updated with:
+
+- the package, affected versions and patched versions
+- a description including Background, Impact, Workaround and Resolution
+- an assessment of the severity using CVSS v3 base metrics
+- a CVE, if an identifier has already been assigned as part of the vulnerability report,
+  it should be re-used, otherwise, a CVE should be requested from the GitHub advisory
+- credits to the reporter if applicable
+
+Publish the advisory
+^^^^^^^^^^^^^^^^^^^^
+
+On release data, all open Pull Requests against the temporary fork should be merged
+in the security advisory - see https://docs.github.com/en/code-security/tutorials/fix-reported-vulnerabilities/collaborate-in-a-fork#merging-changes-in-a-security-advisory
+Once merged, all changes will be visible on the public repository.
+
+The release process can then follow the standard procedures with the following variations:
+
+- the GitHub advisory should be published as described in
+  https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/fix-reported-vulnerabilities/publish-repository-advisory.
+- i naddition to the release announcement, the GitHub advisory should be duplicated to the
+  `list of advisories <https://www.openmicroscopy.org/security/advisories/>`_ on the OME website.
+

--- a/docs/security-process.rst
+++ b/docs/security-process.rst
@@ -1,7 +1,11 @@
 Security process
 ================
 
-OME makes extensive use of GitHub for managing vulnerability reports and fixes - see
+This document describes the security process for OME maintainers. The process for
+reporting a security vulnerability is described in the
+`security page <https://www.openmicroscopy.org/security/>`_ of the OME website.
+This process makes extensive use of GitHub functionalities for managing vulnerability
+reports and fixes - see
 https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities.
 
 Create draft advisory

--- a/docs/security-process.rst
+++ b/docs/security-process.rst
@@ -1,7 +1,7 @@
 Security process
 ================
 
-OME makes extensive use of GitHub  for managing vulnerability reports and fixes - see
+OME makes extensive use of GitHub for managing vulnerability reports and fixes - see
 https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities.
 
 Create draft advisory
@@ -40,7 +40,7 @@ Announce the security release
 
 Once a fix has been identified, a pre-announcement of the upcoming security release
 should be made on the image.sc forum including at least the `ome` and `security` tags.
-The delay between the publication pre-announcement and the security release  may vary
+The delay between the publication pre-announcement and the security release may vary
 depending on a number of factors. For OMERO security releases, sufficient notice should
 be given to system administrators to plan and schedule a downtime and upgrade.
 
@@ -59,7 +59,7 @@ Prior to its publication, the content advisory should be updated with:
 Publish the advisory
 ^^^^^^^^^^^^^^^^^^^^
 
-On release data, all open Pull Requests against the temporary fork should be merged
+On release day, all open Pull Requests against the temporary fork should be merged
 in the security advisory - see https://docs.github.com/en/code-security/tutorials/fix-reported-vulnerabilities/collaborate-in-a-fork#merging-changes-in-a-security-advisory
 Once merged, all changes will be visible on the public repository.
 
@@ -67,6 +67,6 @@ The release process can then follow the standard procedures with the following v
 
 - the GitHub advisory should be published as described in
   https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/fix-reported-vulnerabilities/publish-repository-advisory.
-- i naddition to the release announcement, the GitHub advisory should be duplicated to the
+- in addition to the release announcement, the GitHub advisory should be duplicated to the
   `list of advisories <https://www.openmicroscopy.org/security/advisories/>`_ on the OME website.
 

--- a/docs/security-process.rst
+++ b/docs/security-process.rst
@@ -11,7 +11,7 @@ https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities.
 Create draft advisory
 ^^^^^^^^^^^^^^^^^^^^^
 
-Once a vulnerability is [reported](https://www.openmicroscopy.org/security/) through
+Once a vulnerability is `reported <https://www.openmicroscopy.org/security/>`_ through
 the security mailing list, an administrator should draft a security advisory
 against the appropriate GitHub repository e.g.
 https://github.com/ome/omero-web/security/advisories. This advisory can be used for


### PR DESCRIPTION
This aims to codify OME security process starting from the reception of a report on the mailing list. The transition to using GitHub native security features for the advisory and the fix has been used in all recent security releases:

https://www.openmicroscopy.org/security/advisories/2025-54791/ https://www.openmicroscopy.org/security/advisories/2026-22186/ https://www.openmicroscopy.org/security/advisories/GHSA-j4gv-6x9v-v23g/